### PR TITLE
Hotfix to fix issue with swapping form version files

### DIFF
--- a/app/Models/ModuleVersion.php
+++ b/app/Models/ModuleVersion.php
@@ -7,6 +7,7 @@ use App\Models\Xlsforms\SurveyRow;
 use Carbon\Carbon;
 use App\Imports\ModuleFileImport;
 use App\Imports\ModuleFileUnpack;
+use Illuminate\Validation\ValidationException;
 use Maatwebsite\Excel\Facades\Excel;
 use App\Imports\ModuleFileValidation;
 use App\Models\Traits\HasUploadFields;
@@ -32,8 +33,15 @@ class ModuleVersion extends Model
         //Run validation **before** initial save
         static::saving(function ($moduleVersion) {
 
+            if(!$moduleVersion->file) {
+                throw ValidationException::withMessages([
+                    'file' => 'Please add an XLS file for the module',
+                ]);
+            }
 
-            Excel::import(new ModuleFileValidation($moduleVersion), $moduleVersion->file);
+            if (request() && request()->hasFile('file')) {
+                Excel::import(new ModuleFileValidation($moduleVersion), request()->file('file'));
+            }
 
         });
 


### PR DESCRIPTION
This PR (hopefully) fixes the issue where sometimes a user will remove an existing file from a draft version, and upload a new one, and the operation will fail because the old file is being referenced after being deleted. 

